### PR TITLE
Adding a step prior to doing the generinc line-by-line review

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _Based off work by [BoringCrypto](https://github.com/sushiswap/bentobox/blob/mas
 - Create a threat model and make a list of theoretical high level attack vectors.
 - Look at areas that can do value exchange. Especially functions like `transfer`, `transferFrom`, `send`, `call`, `delegatecall`, and `selfdestruct`. Walk backward from them to ensure they are secured properly.
 - Look at areas that interface with external contracts and ensure all assumptions about them are valid like share price only increases, etc.
+- Do a review focused on protocol's functionalities, analyze how each of the core functions are implemented among the contracts.
 - Do a generic line-by-line review of the contracts.
 - Do another review from the perspective of every actor in the threat model.
 - Glance over the project's tests + code coverage and look deeper at areas lacking coverage.


### PR DESCRIPTION
I've found out that reviewing the contracts based on their functionalities has helped me a lot rather than going directly to the line-by-line review.

What do I mean?
- After taking a glance at the contract's code and reading the documentation, the auditor has (or should) already identified some of the main functionalities of the contracts, such as, depositing, staking, withdrawing, borrowing, liquidating, you name it, now, the idea is to analyze how each of these functions is implemented, most of the times the functions have dependencies and interact with functions of different contracts, this approach will help a lot to confirm and or discard the current mental models about the system, plus it is quite less tedious and more digestive to understand functionalities than trying to connect the dots by reading code that is not necessary relevant to what you've just read (when reading line-by-line).